### PR TITLE
feat(auth): add Redis cache for JWT tokens

### DIFF
--- a/backend/apps/identity/src/queries/validate-token/validate-token.handler.ts
+++ b/backend/apps/identity/src/queries/validate-token/validate-token.handler.ts
@@ -3,6 +3,7 @@ import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { JwtService } from '@nestjs/jwt';
 import { RpcException } from '@nestjs/microservices';
 import { ErrorCode, RedisHelper } from '@app/common';
+import now = jest.now;
 
 @QueryHandler(ValidateTokenQuery)
 export class ValidateTokenHandler implements IQueryHandler<ValidateTokenQuery> {
@@ -13,17 +14,34 @@ export class ValidateTokenHandler implements IQueryHandler<ValidateTokenQuery> {
 
   async execute(query: ValidateTokenQuery): Promise<any> {
     try {
-      const decoded = this.jwtService.verify(query.token);
+      const decoded = this.jwtService.decode(query.token);
 
-      if (!decoded) {
+      if (!decoded || !decoded.tokenId || !decoded.sub) {
         throw new RpcException(ErrorCode.INVALID_JWT_TOKEN);
       }
 
-      const redisKey = `access:${decoded.sub}`;
-      const isBlacklisted = await this.redisHelper.get(redisKey);
+      const validatedKey = `validated:${decoded.tokenId}`;
+      const cached = await this.redisHelper.get(validatedKey);
+
+      if (cached) {
+        return {
+          valid: true,
+          userId: decoded.sub,
+          role: decoded.role,
+        };
+      }
+
+      const blacklistKey = `access:${decoded.sub}`;
+      const isBlacklisted = await this.redisHelper.get(blacklistKey);
+
       if (isBlacklisted) {
         return { valid: false, userId: null, role: null };
       }
+
+      const verified = await this.jwtService.verify(query.token);
+
+      const ttl = verified.exp - Math.floor(Date.now() / 1000);
+      await this.redisHelper.set(validatedKey, '1', ttl);
 
       return {
         valid: true,


### PR DESCRIPTION
- Blacklist access tokens on sign-out
- Store and delete refresh tokens in Redis
- Cache validated state of access tokens to skip repeated JWT verification
- Ensure validate-token query checks blacklist